### PR TITLE
Scaffold responsive trivia game experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,97 @@
-# Trivial-Maison
+# Trivial Maison
+
+A responsive trivia night experience built with React and Vite. The interface adapts to desktop browsers, tablets, and mobile phones, making it easy to play on touch or mouse-driven devices. Players roll a die, move around the digital board, answer category questions, earn wedges, and race to complete their collection first.
+
+## Project structure
+
+```
+Trivial-Maison/
+├── assets/                # Sample question packs and icons
+│   └── questions.json     # Ready-to-edit sample questions
+├── src/
+│   ├── components/        # React UI components (board, question view, setup, etc.)
+│   ├── game/              # Core game state + rules engine
+│   │   ├── __tests__/     # Automated unit tests (Vitest)
+│   │   └── ...
+│   ├── App.tsx            # Main application shell
+│   ├── main.tsx           # React entry point
+│   ├── styles.css         # Shared styling + responsive layout
+│   └── vite-env.d.ts
+├── index.html             # Vite HTML template
+├── package.json           # Dependencies and scripts
+└── vite.config.ts         # Build + test configuration
+```
+
+## Getting started
+
+### Requirements
+
+- [Node.js](https://nodejs.org/) 18 or newer
+- npm (bundled with Node)
+
+### Install dependencies
+
+```bash
+npm install
+```
+
+### Run the development server
+
+```bash
+npm run dev
+```
+
+Vite will output a local URL (typically http://localhost:5173). Open it in a desktop browser, tablet, or phone. The layout automatically adapts to different screen sizes and pointer types.
+
+### Build for production
+
+```bash
+npm run build
+```
+
+The optimized assets will be emitted to the `dist/` directory. Preview the built bundle with:
+
+```bash
+npm run preview
+```
+
+### Run automated tests
+
+```bash
+npm test
+```
+
+Vitest covers critical game rules such as question drawing, scoring, and turn rotation. The suite runs in a JSDOM environment and can be expanded with additional scenarios.
+
+## Gameplay overview
+
+1. Add between two and six player names in the setup screen and start the game.
+2. On each turn, a player rolls the die, moves across the board, and draws a question in the landing category.
+3. Answer correctly on a wedge space to earn that category’s wedge and increase your score.
+4. Incorrect answers end the turn; play passes to the next participant.
+5. The first player to collect all wedges wins and can immediately restart a new round.
+
+## Managing questions
+
+Sample data lives in [`assets/questions.json`](./assets/questions.json). Each category contains:
+
+- `id`: unique identifier (used internally)
+- `name`: display label
+- `color`: accent color for the UI (hex string)
+- `questions`: an array of prompts with multiple-choice options and the `answerIndex`
+
+To add more trivia:
+
+1. Duplicate an existing category block or append new questions to a category.
+2. Ensure every `answerIndex` matches the zero-based position of the correct option.
+3. Save the file and restart the development server (or reload the page during development). The decks automatically refresh.
+
+You can also add new assets (icons, audio cues, etc.) to the `assets/` directory and import them where needed.
+
+## Customizing the experience
+
+- Adjust the board layout or wedge distribution by editing `src/game/questions.ts`.
+- Extend the rules engine (e.g., timed rounds, penalties) in `src/game/engine.ts`.
+- Refine styles or add themes inside `src/styles.css`.
+
+Feel free to tailor the trivia packs and visuals to match your event or brand.

--- a/assets/questions.json
+++ b/assets/questions.json
@@ -1,0 +1,154 @@
+{
+  "categories": [
+    {
+      "id": "arts",
+      "name": "Arts & Culture",
+      "color": "#9333ea",
+      "questions": [
+        {
+          "id": "arts-1",
+          "prompt": "Which artist is known for painting the ceiling of the Sistine Chapel?",
+          "options": ["Vincent van Gogh", "Michelangelo", "Claude Monet", "Pablo Picasso"],
+          "answerIndex": 1
+        },
+        {
+          "id": "arts-2",
+          "prompt": "The novel '1984' was written by which author?",
+          "options": ["George Orwell", "Aldous Huxley", "Ray Bradbury", "Margaret Atwood"],
+          "answerIndex": 0
+        },
+        {
+          "id": "arts-3",
+          "prompt": "Ballet originated in which European country?",
+          "options": ["France", "Spain", "Italy", "Russia"],
+          "answerIndex": 2
+        }
+      ]
+    },
+    {
+      "id": "science",
+      "name": "Science & Nature",
+      "color": "#16a34a",
+      "questions": [
+        {
+          "id": "science-1",
+          "prompt": "What gas do plants absorb from the atmosphere during photosynthesis?",
+          "options": ["Oxygen", "Carbon Dioxide", "Nitrogen", "Hydrogen"],
+          "answerIndex": 1
+        },
+        {
+          "id": "science-2",
+          "prompt": "How many bones are in the adult human body?",
+          "options": ["198", "206", "214", "180"],
+          "answerIndex": 1
+        },
+        {
+          "id": "science-3",
+          "prompt": "Which planet is known as the Red Planet?",
+          "options": ["Venus", "Mars", "Jupiter", "Saturn"],
+          "answerIndex": 1
+        }
+      ]
+    },
+    {
+      "id": "history",
+      "name": "History",
+      "color": "#f97316",
+      "questions": [
+        {
+          "id": "history-1",
+          "prompt": "Who was the first President of the United States?",
+          "options": ["Abraham Lincoln", "George Washington", "John Adams", "Thomas Jefferson"],
+          "answerIndex": 1
+        },
+        {
+          "id": "history-2",
+          "prompt": "In which year did World War II end?",
+          "options": ["1945", "1939", "1942", "1951"],
+          "answerIndex": 0
+        },
+        {
+          "id": "history-3",
+          "prompt": "The Great Wall is located in which country?",
+          "options": ["China", "India", "Japan", "Mongolia"],
+          "answerIndex": 0
+        }
+      ]
+    },
+    {
+      "id": "geography",
+      "name": "Geography",
+      "color": "#2563eb",
+      "questions": [
+        {
+          "id": "geography-1",
+          "prompt": "What is the longest river in the world?",
+          "options": ["Amazon", "Nile", "Yangtze", "Mississippi"],
+          "answerIndex": 1
+        },
+        {
+          "id": "geography-2",
+          "prompt": "Which continent is the Sahara Desert located on?",
+          "options": ["Africa", "Asia", "Australia", "South America"],
+          "answerIndex": 0
+        },
+        {
+          "id": "geography-3",
+          "prompt": "Mount Kilimanjaro is found in which country?",
+          "options": ["Kenya", "Tanzania", "Ethiopia", "Uganda"],
+          "answerIndex": 1
+        }
+      ]
+    },
+    {
+      "id": "entertainment",
+      "name": "Entertainment",
+      "color": "#facc15",
+      "questions": [
+        {
+          "id": "entertainment-1",
+          "prompt": "Which movie features the quote, 'May the Force be with you'?",
+          "options": ["Star Wars", "The Matrix", "Star Trek", "Avatar"],
+          "answerIndex": 0
+        },
+        {
+          "id": "entertainment-2",
+          "prompt": "What is the stage name of the artist Stefani Germanotta?",
+          "options": ["Lady Gaga", "Madonna", "Katy Perry", "Lorde"],
+          "answerIndex": 0
+        },
+        {
+          "id": "entertainment-3",
+          "prompt": "Which television series is set in the fictional town of Hawkins, Indiana?",
+          "options": ["The X-Files", "Stranger Things", "Twin Peaks", "Lost"],
+          "answerIndex": 1
+        }
+      ]
+    },
+    {
+      "id": "sports",
+      "name": "Sports & Leisure",
+      "color": "#ec4899",
+      "questions": [
+        {
+          "id": "sports-1",
+          "prompt": "How many players are on the field for each team in soccer?",
+          "options": ["9", "10", "11", "12"],
+          "answerIndex": 2
+        },
+        {
+          "id": "sports-2",
+          "prompt": "In tennis, what piece of fruit is found at the top of the men's Wimbledon trophy?",
+          "options": ["Apple", "Pineapple", "Pear", "Banana"],
+          "answerIndex": 1
+        },
+        {
+          "id": "sports-3",
+          "prompt": "Which sport uses the terms 'strike' and 'spare'?",
+          "options": ["Baseball", "Bowling", "Cricket", "Rugby"],
+          "answerIndex": 1
+        }
+      ]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Trivial Maison</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "trivial-maison",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.23",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.0",
+    "jsdom": "^24.0.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0",
+    "vitest": "^1.3.1"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,169 @@
+import { useMemo, useState } from "react";
+import { Board } from "./components/Board";
+import { QuestionView } from "./components/QuestionView";
+import { Scoreboard } from "./components/Scoreboard";
+import { SetupForm } from "./components/SetupForm";
+import {
+  applyRoll,
+  answerQuestion,
+  createInitialGameState,
+  proceedToNextTurn,
+  resetGame,
+  rollDie
+} from "./game/engine";
+import type { Category, GameState } from "./game/types";
+
+const DEFAULT_PLAYERS = ["Alex", "Jordan"];
+
+function useCategories(game: GameState | null): Category[] {
+  return useMemo(() => game?.categories ?? [], [game]);
+}
+
+export default function App() {
+  const [playerNames, setPlayerNames] = useState<string[]>(DEFAULT_PLAYERS);
+  const [game, setGame] = useState<GameState | null>(null);
+
+  const categories = useCategories(game);
+  const currentPlayer = game ? game.players[game.currentPlayerIndex] : undefined;
+
+  const handleStartGame = () => {
+    setGame(createInitialGameState(playerNames));
+  };
+
+  const handleRoll = () => {
+    if (!game) return;
+    const value = rollDie();
+    setGame(applyRoll(game, value));
+  };
+
+  const handleAnswer = (index: number) => {
+    if (!game) return;
+    setGame(answerQuestion(game, index));
+  };
+
+  const handleNextTurn = () => {
+    if (!game) return;
+    setGame(proceedToNextTurn(game));
+  };
+
+  const handleRestart = () => {
+    if (!game) return;
+    setGame(resetGame(game, playerNames));
+  };
+
+  const handleChangePlayerName = (index: number, value: string) => {
+    setPlayerNames((previous) => {
+      const next = [...previous];
+      next[index] = value;
+      return next;
+    });
+  };
+
+  const handleAddPlayer = () => {
+    setPlayerNames((previous) => [...previous, `Player ${previous.length + 1}`]);
+  };
+
+  const handleRemovePlayer = (index: number) => {
+    setPlayerNames((previous) => previous.filter((_, i) => i !== index));
+  };
+
+  const currentCategory: Category | undefined = useMemo(() => {
+    if (!game || !currentPlayer) return undefined;
+    const space = game.board[currentPlayer.position];
+    return categories.find((category) => category.id === space.categoryId);
+  }, [game, currentPlayer, categories]);
+
+  return (
+    <div className="app-container">
+      <header>
+        <h1>Trivial Maison</h1>
+        <p>Collect all category wedges before your rivals to win the trivia crown.</p>
+      </header>
+      <main>
+        {!game && (
+          <SetupForm
+            playerNames={playerNames}
+            onUpdatePlayerName={handleChangePlayerName}
+            onAddPlayer={handleAddPlayer}
+            onRemovePlayer={handleRemovePlayer}
+            onStartGame={handleStartGame}
+          />
+        )}
+        {game && (
+          <>
+            <Scoreboard
+              players={game.players}
+              categories={categories}
+              currentPlayerId={currentPlayer?.id}
+            />
+            <Board
+              spaces={game.board}
+              players={game.players}
+              categories={categories}
+              currentPlayerId={currentPlayer?.id}
+            />
+            <section className="panel" aria-label="Turn controls">
+              <h2>Turn</h2>
+              {currentPlayer && (
+                <p className="turn-info">
+                  <strong>{currentPlayer.name}</strong> is up.
+                </p>
+              )}
+              <div className="turn-controls">
+                <button
+                  type="button"
+                  className="button"
+                  onClick={handleRoll}
+                  disabled={game.phase !== "awaiting-roll"}
+                >
+                  Roll Die
+                </button>
+                <button
+                  type="button"
+                  className="button"
+                  onClick={handleNextTurn}
+                  disabled={game.phase !== "feedback"}
+                >
+                  Next Turn
+                </button>
+                <button type="button" className="button" onClick={handleRestart}>
+                  Restart Round
+                </button>
+                <button
+                  type="button"
+                  className="button"
+                  onClick={() => setGame(null)}
+                >
+                  Change Players
+                </button>
+              </div>
+              <p className="turn-info">
+                Phase: <strong>{game.phase}</strong>
+                {typeof game.diceValue === "number" && ` · Last roll: ${game.diceValue}`}
+              </p>
+              {game.phase === "finished" && game.winnerId && (
+                <p className="turn-info">
+                  🎉 {game.players.find((player) => player.id === game.winnerId)?.name} collected
+                  all wedges and wins the game!
+                </p>
+              )}
+            </section>
+            <QuestionView
+              question={game.activeQuestion}
+              category={currentCategory}
+              phase={game.phase}
+              diceValue={game.diceValue}
+              selectedAnswerIndex={game.selectedAnswerIndex}
+              wasAnswerCorrect={game.wasAnswerCorrect}
+              onSelectAnswer={handleAnswer}
+            />
+          </>
+        )}
+      </main>
+      <footer>
+        Sample questions are bundled in <code>assets/questions.json</code>. Add more categories or
+        questions there, restart the dev server, and the new content will load automatically.
+      </footer>
+    </div>
+  );
+}

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,0 +1,80 @@
+import type { Category, PlayerState, Space } from "../game/types";
+
+const PLAYER_COLORS = [
+  "#2563eb",
+  "#9333ea",
+  "#16a34a",
+  "#f97316",
+  "#facc15",
+  "#ec4899"
+];
+
+interface BoardProps {
+  spaces: Space[];
+  players: PlayerState[];
+  categories: Category[];
+  currentPlayerId?: string;
+}
+
+export function Board({
+  spaces,
+  players,
+  categories,
+  currentPlayerId
+}: BoardProps) {
+  const categoryLookup = new Map(categories.map((category) => [category.id, category]));
+  const playerColorMap = new Map(
+    players.map((player, index) => [player.id, PLAYER_COLORS[index % PLAYER_COLORS.length]])
+  );
+
+  return (
+    <section className="panel" aria-label="Game board">
+      <h2>Board</h2>
+      <div className="board-grid">
+        {spaces.map((space) => {
+          const occupyingPlayers = players.filter(
+            (player) => player.position === space.index
+          );
+          const isActiveSpace = occupyingPlayers.some(
+            (player) => player.id === currentPlayerId
+          );
+          const category = categoryLookup.get(space.categoryId);
+
+          return (
+            <div
+              key={space.index}
+              className={`board-space${space.isWedge ? " wedge" : ""}${
+                isActiveSpace ? " active" : ""
+              }`}
+              style={{
+                borderColor: category?.color ?? "#cbd5f5"
+              }}
+              role="group"
+              aria-label={`${category?.name ?? "Space"} space ${
+                space.isWedge ? "(wedge)" : ""
+              }`}
+            >
+              <strong>{category?.name ?? space.categoryId}</strong>
+              <span className="badge">#{space.index + 1}</span>
+              <div aria-label="Player tokens on this space">
+                {occupyingPlayers.map((player) => {
+                  const color = playerColorMap.get(player.id) ?? "#2563eb";
+                  return (
+                    <span
+                      key={player.id}
+                      className="player-token"
+                      style={{ backgroundColor: color }}
+                      title={player.name}
+                    >
+                      {player.name.charAt(0).toUpperCase()}
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/QuestionView.tsx
+++ b/src/components/QuestionView.tsx
@@ -1,0 +1,87 @@
+import type { Category, Phase, Question } from "../game/types";
+
+interface QuestionViewProps {
+  question?: Question;
+  category?: Category;
+  phase: Phase;
+  diceValue?: number;
+  selectedAnswerIndex?: number;
+  wasAnswerCorrect?: boolean;
+  onSelectAnswer: (index: number) => void;
+}
+
+export function QuestionView({
+  question,
+  category,
+  phase,
+  diceValue,
+  selectedAnswerIndex,
+  wasAnswerCorrect,
+  onSelectAnswer
+}: QuestionViewProps) {
+  if (!question) {
+    return (
+      <section className="panel" aria-label="Awaiting question">
+        <h2>Question</h2>
+        <p className="turn-info">
+          Roll the die to draw a question and move across the board.
+        </p>
+      </section>
+    );
+  }
+
+  const isAnswering = phase === "question";
+  const isFeedback = phase === "feedback" || phase === "finished";
+
+  return (
+    <section className="panel" aria-label="Question prompt">
+      <div className="question-card">
+        <header>
+          <h2>{category?.name ?? "Question"}</h2>
+          <div className="turn-info">
+            {typeof diceValue === "number" && (
+              <span className="badge" aria-label="Dice result">
+                Rolled {diceValue}
+              </span>
+            )}
+            {category && (
+              <span className="badge" style={{ backgroundColor: `${category.color}22`, color: category.color }}>
+                Category: {category.name}
+              </span>
+            )}
+          </div>
+        </header>
+        <p>{question.prompt}</p>
+        <div className="question-options">
+          {question.options.map((option, index) => {
+            const isSelected = selectedAnswerIndex === index;
+            const isCorrectAnswer = question.answerIndex === index;
+            const buttonState = isFeedback
+              ? isCorrectAnswer
+                ? "correct"
+                : isSelected
+                ? "incorrect"
+                : ""
+              : "";
+            return (
+              <button
+                key={option}
+                type="button"
+                className={`option-button${buttonState ? ` ${buttonState}` : ""}`}
+                onClick={() => onSelectAnswer(index)}
+                disabled={!isAnswering}
+              >
+                {option}
+              </button>
+            );
+          })}
+        </div>
+        {isFeedback && (
+          <footer className="turn-info">
+            {wasAnswerCorrect ? "Correct!" : "Not quite. The correct answer is highlighted."}
+          </footer>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -1,0 +1,57 @@
+import type { Category, PlayerState } from "../game/types";
+
+interface ScoreboardProps {
+  players: PlayerState[];
+  categories: Category[];
+  currentPlayerId?: string;
+}
+
+export function Scoreboard({
+  players,
+  categories,
+  currentPlayerId
+}: ScoreboardProps) {
+  return (
+    <section className="panel" aria-label="Scoreboard">
+      <h2>Players</h2>
+      <div className="player-list">
+        {players.map((player) => {
+          const isActive = player.id === currentPlayerId;
+
+          return (
+            <article
+              key={player.id}
+              className={`player-card${isActive ? " active" : ""}`}
+              aria-label={`${player.name} score card`}
+            >
+              <div className="score-row">
+                <strong>{player.name}</strong>
+                <span className="badge">Score: {player.score}</span>
+              </div>
+              <div className="turn-info" role="list" aria-label="Wedges collected">
+                {categories.map((category) => {
+                  const hasWedge = player.wedges.includes(category.id);
+                  return (
+                    <span
+                      key={`${player.id}-${category.id}`}
+                      className="status-chip"
+                      style={{
+                        backgroundColor: hasWedge
+                          ? `${category.color}22`
+                          : "rgba(148, 163, 184, 0.15)",
+                        color: hasWedge ? category.color : "#475569"
+                      }}
+                      role="listitem"
+                    >
+                      {category.name.split(" ")[0]}
+                    </span>
+                  );
+                })}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/SetupForm.tsx
+++ b/src/components/SetupForm.tsx
@@ -1,0 +1,68 @@
+interface SetupFormProps {
+  playerNames: string[];
+  onUpdatePlayerName: (index: number, value: string) => void;
+  onAddPlayer: () => void;
+  onRemovePlayer: (index: number) => void;
+  onStartGame: () => void;
+}
+
+export function SetupForm({
+  playerNames,
+  onUpdatePlayerName,
+  onAddPlayer,
+  onRemovePlayer,
+  onStartGame
+}: SetupFormProps) {
+  return (
+    <section className="panel" aria-label="Player setup">
+      <h2>Players</h2>
+      <form
+        className="player-setup"
+        onSubmit={(event) => {
+          event.preventDefault();
+          onStartGame();
+        }}
+      >
+        <div className="player-inputs">
+          {playerNames.map((name, index) => (
+            <label key={index}>
+              <span>Player {index + 1}</span>
+              <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(event) => onUpdatePlayerName(index, event.target.value)}
+                  placeholder={`Enter name for player ${index + 1}`}
+                  required
+                  minLength={1}
+                />
+                {playerNames.length > 2 && (
+                  <button
+                    type="button"
+                    className="button"
+                    style={{ background: "#e11d48" }}
+                    onClick={() => onRemovePlayer(index)}
+                    aria-label={`Remove player ${index + 1}`}
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
+            </label>
+          ))}
+        </div>
+        <button
+          type="button"
+          className="add-player-button"
+          onClick={onAddPlayer}
+          disabled={playerNames.length >= 6}
+        >
+          + Add another player
+        </button>
+        <button type="submit" className="button">
+          Start Game
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/game/__tests__/engine.test.ts
+++ b/src/game/__tests__/engine.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  answerQuestion,
+  applyRoll,
+  createInitialGameState,
+  proceedToNextTurn
+} from "../engine";
+
+function startGame() {
+  return createInitialGameState(["Ada", "Grace"]);
+}
+
+describe("game engine", () => {
+  it("draws a question and reduces the deck when a player rolls", () => {
+    const initial = startGame();
+    const categoryId = initial.board[1].categoryId;
+    const initialDeckLength = initial.questionDeck[categoryId]?.length ?? 0;
+    expect(initialDeckLength).toBeGreaterThan(0);
+
+    const afterRoll = applyRoll(initial, 1);
+
+    expect(afterRoll.activeQuestion).toBeDefined();
+    expect(afterRoll.diceValue).toBe(1);
+    expect(afterRoll.phase).toBe("question");
+    expect(afterRoll.questionDeck[categoryId]).toHaveLength(initialDeckLength - 1);
+  });
+
+  it("awards a wedge and increments score for a correct answer on a wedge space", () => {
+    const initial = startGame();
+    const afterRoll = applyRoll(initial, 1);
+    const question = afterRoll.activeQuestion;
+    if (!question) {
+      throw new Error("Expected a question to be active");
+    }
+
+    const afterAnswer = answerQuestion(afterRoll, question.answerIndex);
+    const player = afterAnswer.players[afterAnswer.currentPlayerIndex];
+
+    expect(player.score).toBe(1);
+    expect(player.wedges).toContain(question.categoryId);
+    expect(["feedback", "finished"]).toContain(afterAnswer.phase);
+  });
+
+  it("passes control to the next player after feedback", () => {
+    const initial = startGame();
+    const afterRoll = applyRoll(initial, 2);
+    const question = afterRoll.activeQuestion;
+    if (!question) {
+      throw new Error("Expected a question to be active");
+    }
+
+    const afterAnswer = answerQuestion(afterRoll, (question.answerIndex + 1) % question.options.length);
+    expect(afterAnswer.phase).toBe("feedback");
+
+    const nextTurn = proceedToNextTurn(afterAnswer);
+    expect(nextTurn.currentPlayerIndex).toBe(1);
+    expect(nextTurn.phase).toBe("awaiting-roll");
+    expect(nextTurn.activeQuestion).toBeUndefined();
+    expect(nextTurn.diceValue).toBeUndefined();
+  });
+});

--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -1,0 +1,201 @@
+import { categories, createBoardSpaces, createQuestionDeck } from "./questions";
+import type { GameState, PlayerState, Question } from "./types";
+
+export function createPlayers(playerNames: string[]): PlayerState[] {
+  return playerNames.map((name, index) => ({
+    id: `player-${index + 1}`,
+    name: name.trim() || `Player ${index + 1}`,
+    position: 0,
+    wedges: [],
+    score: 0
+  }));
+}
+
+export function createInitialGameState(playerNames: string[]): GameState {
+  const sanitized = playerNames
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
+
+  const players = createPlayers(
+    sanitized.length > 0 ? sanitized : ["Player 1", "Player 2"]
+  );
+
+  const board = createBoardSpaces();
+  const questionDeck = createQuestionDeck();
+  const discardPile = Object.fromEntries(
+    Object.keys(questionDeck).map((categoryId) => [categoryId, [] as Question[]])
+  );
+
+  return {
+    players,
+    currentPlayerIndex: 0,
+    board,
+    categories,
+    questionDeck,
+    discardPile,
+    phase: "awaiting-roll"
+  };
+}
+
+export function rollDie(random: () => number = Math.random): number {
+  const value = Math.floor(random() * 6) + 1;
+  return Math.max(1, Math.min(6, value));
+}
+
+function drawQuestionFromDeck(
+  state: GameState,
+  categoryId: string
+): {
+  question: Question;
+  deck: Record<string, Question[]>;
+  discard: Record<string, Question[]>;
+} {
+  const currentDeck = state.questionDeck[categoryId] ?? [];
+  const currentDiscard = state.discardPile[categoryId] ?? [];
+
+  let workingDeck = [...currentDeck];
+  let workingDiscard = [...currentDiscard];
+
+  if (workingDeck.length === 0) {
+    if (workingDiscard.length === 0) {
+      throw new Error(`No questions available for category ${categoryId}`);
+    }
+    workingDeck = [...workingDiscard];
+    workingDiscard = [];
+  }
+
+  const [question, ...remainingDeck] = workingDeck;
+
+  return {
+    question,
+    deck: {
+      ...state.questionDeck,
+      [categoryId]: remainingDeck
+    },
+    discard: {
+      ...state.discardPile,
+      [categoryId]: workingDiscard
+    }
+  };
+}
+
+export function applyRoll(state: GameState, diceValue: number): GameState {
+  if (state.phase !== "awaiting-roll") {
+    return state;
+  }
+
+  const boardSize = state.board.length;
+  const players = state.players.map((player, index) => {
+    if (index !== state.currentPlayerIndex) {
+      return player;
+    }
+    const nextPosition = (player.position + diceValue) % boardSize;
+    return {
+      ...player,
+      position: nextPosition
+    };
+  });
+
+  const currentPlayer = players[state.currentPlayerIndex];
+  const space = state.board[currentPlayer.position];
+  const { question, deck, discard } = drawQuestionFromDeck(state, space.categoryId);
+
+  return {
+    ...state,
+    players,
+    diceValue,
+    questionDeck: deck,
+    discardPile: discard,
+    activeQuestion: question,
+    phase: "question",
+    selectedAnswerIndex: undefined,
+    wasAnswerCorrect: undefined
+  };
+}
+
+export function answerQuestion(
+  state: GameState,
+  selectedIndex: number
+): GameState {
+  if (state.phase !== "question" || !state.activeQuestion) {
+    return state;
+  }
+
+  const question = state.activeQuestion;
+  const isCorrect = question.answerIndex === selectedIndex;
+
+  const players = state.players.map((player, index) => {
+    if (index !== state.currentPlayerIndex) {
+      return player;
+    }
+
+    let wedges = player.wedges;
+    let score = player.score;
+
+    if (isCorrect) {
+      score += 1;
+      const currentSpace = state.board[player.position];
+      const hasWedge = wedges.includes(question.categoryId);
+      if (currentSpace.isWedge && !hasWedge) {
+        wedges = [...wedges, question.categoryId];
+      }
+    }
+
+    return {
+      ...player,
+      wedges,
+      score
+    };
+  });
+
+  const discardPile = {
+    ...state.discardPile,
+    [question.categoryId]: [
+      ...(state.discardPile[question.categoryId] ?? []),
+      question
+    ]
+  };
+
+  const currentPlayer = players[state.currentPlayerIndex];
+  const hasAllWedges = currentPlayer.wedges.length === state.categories.length;
+  const winnerId = isCorrect && hasAllWedges ? currentPlayer.id : state.winnerId;
+
+  return {
+    ...state,
+    players,
+    discardPile,
+    wasAnswerCorrect: isCorrect,
+    selectedAnswerIndex: selectedIndex,
+    winnerId,
+    phase: winnerId ? "finished" : "feedback"
+  };
+}
+
+export function proceedToNextTurn(state: GameState): GameState {
+  if (state.phase !== "feedback") {
+    return state;
+  }
+
+  const nextPlayerIndex = (state.currentPlayerIndex + 1) % state.players.length;
+
+  return {
+    ...state,
+    currentPlayerIndex: nextPlayerIndex,
+    phase: "awaiting-roll",
+    diceValue: undefined,
+    activeQuestion: undefined,
+    wasAnswerCorrect: undefined,
+    selectedAnswerIndex: undefined
+  };
+}
+
+export function resetGame(state: GameState, playerNames: string[]): GameState {
+  const initial = createInitialGameState(playerNames);
+  return {
+    ...initial,
+    players: initial.players.map((player, index) => ({
+      ...player,
+      name: playerNames[index] ?? player.name
+    }))
+  };
+}

--- a/src/game/questions.ts
+++ b/src/game/questions.ts
@@ -1,0 +1,71 @@
+import rawData from "../../assets/questions.json";
+import type { Category, Question, Space } from "./types";
+
+interface RawQuestion {
+  id: string;
+  prompt: string;
+  options: string[];
+  answerIndex: number;
+}
+
+interface RawCategory {
+  id: string;
+  name: string;
+  color: string;
+  questions: RawQuestion[];
+}
+
+type QuestionsFile = {
+  categories: RawCategory[];
+};
+
+const parsed = rawData as QuestionsFile;
+
+export const categories: Category[] = parsed.categories.map((category) => ({
+  id: category.id,
+  name: category.name,
+  color: category.color
+}));
+
+export function createBoardSpaces(): Space[] {
+  const laps = 4;
+  const board: Space[] = [];
+
+  for (let lap = 0; lap < laps; lap += 1) {
+    parsed.categories.forEach((category) => {
+      board.push({
+        index: board.length,
+        categoryId: category.id,
+        isWedge: lap === 0
+      });
+    });
+  }
+
+  return board;
+}
+
+export function createQuestionDeck(): Record<string, Question[]> {
+  return parsed.categories.reduce<Record<string, Question[]>>(
+    (accumulator, category) => {
+      accumulator[category.id] = category.questions.map((question) => ({
+        ...question,
+        categoryId: category.id
+      }));
+      return accumulator;
+    },
+    {}
+  );
+}
+
+export type CategoryWithQuestions = RawCategory & {
+  questions: (RawQuestion & { categoryId: string })[];
+};
+
+export const categoriesWithQuestions: CategoryWithQuestions[] =
+  parsed.categories.map((category) => ({
+    ...category,
+    questions: category.questions.map((question) => ({
+      ...question,
+      categoryId: category.id
+    }))
+  }));

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -1,0 +1,49 @@
+export interface Question {
+  id: string;
+  prompt: string;
+  options: string[];
+  answerIndex: number;
+  categoryId: string;
+}
+
+export interface Category {
+  id: string;
+  name: string;
+  color: string;
+}
+
+export interface Space {
+  index: number;
+  categoryId: string;
+  isWedge: boolean;
+}
+
+export interface PlayerState {
+  id: string;
+  name: string;
+  position: number;
+  wedges: string[];
+  score: number;
+}
+
+export type Phase =
+  | "setup"
+  | "awaiting-roll"
+  | "question"
+  | "feedback"
+  | "finished";
+
+export interface GameState {
+  players: PlayerState[];
+  currentPlayerIndex: number;
+  board: Space[];
+  categories: Category[];
+  questionDeck: Record<string, Question[]>;
+  discardPile: Record<string, Question[]>;
+  phase: Phase;
+  diceValue?: number;
+  activeQuestion?: Question;
+  wasAnswerCorrect?: boolean;
+  selectedAnswerIndex?: number;
+  winnerId?: string;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,289 @@
+:root {
+  font-family: "Inter", system-ui, sans-serif;
+  color: #1f2933;
+  background-color: #f5f7fa;
+  line-height: 1.5;
+}
+
+body,
+html {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  padding: 1rem;
+}
+
+#root {
+  width: 100%;
+}
+
+.app-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 8px 30px rgba(15, 23, 42, 0.15);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - 2rem);
+}
+
+header {
+  background: linear-gradient(135deg, #2563eb, #9333ea);
+  color: white;
+  padding: 1.5rem;
+  text-align: center;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  flex: 1;
+}
+
+@media (min-width: 960px) {
+  main {
+    flex-direction: row;
+  }
+}
+
+.panel {
+  background-color: #f8fafc;
+  border-radius: 12px;
+  padding: 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.button {
+  background: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.3);
+}
+
+.board-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: 0.75rem;
+}
+
+.board-space {
+  border-radius: 12px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background: white;
+  border: 2px solid transparent;
+  gap: 0.25rem;
+  min-height: 90px;
+  position: relative;
+}
+
+.board-space.wedge::after {
+  content: "★";
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  font-size: 1rem;
+}
+
+.board-space.active {
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.4);
+}
+
+.player-token {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 700;
+  margin-top: 0.25rem;
+}
+
+.player-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.player-card {
+  background-color: white;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.player-card.active {
+  border-color: #2563eb;
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.2);
+}
+
+.score-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background-color: #e2e8f0;
+}
+
+.question-card {
+  background: white;
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.question-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.option-button {
+  background-color: white;
+  border: 2px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 0.75rem;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.option-button:hover {
+  border-color: #2563eb;
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.15);
+}
+
+.option-button.correct {
+  border-color: #16a34a;
+  background-color: #dcfce7;
+}
+
+.option-button.incorrect {
+  border-color: #dc2626;
+  background-color: #fee2e2;
+}
+
+.turn-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.turn-info {
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+footer {
+  padding: 1rem 1.5rem;
+  background-color: #f8fafc;
+  font-size: 0.8rem;
+  text-align: center;
+  color: #64748b;
+}
+
+input,
+select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  font-size: 1rem;
+}
+
+form.player-setup {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.player-inputs {
+  display: grid;
+  gap: 0.5rem;
+}
+
+@media (min-width: 640px) {
+  .player-inputs {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.add-player-button {
+  background: none;
+  color: #2563eb;
+  border: 2px dashed #2563eb;
+  padding: 0.5rem;
+  border-radius: 12px;
+  cursor: pointer;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background-color: rgba(37, 99, 235, 0.1);
+  color: #1d4ed8;
+}
+
+@media (max-width: 600px) {
+  header {
+    padding: 1rem;
+  }
+
+  .question-options {
+    grid-template-columns: 1fr;
+  }
+
+  .board-space {
+    min-height: 70px;
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "vitest.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./vitest.setup.ts"
+  }
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+// Global test setup can be added here.


### PR DESCRIPTION
## Summary
- scaffold a Vite + React project structure with responsive styling and player setup UX
- implement board navigation, dice rolls, question handling, scoring, and wedge win logic in the shared game engine
- add sample question data, guidance for extending packs, and Vitest coverage for question selection, scoring, and turn rotation

## Testing
- npm test *(fails: vitest executable missing because npm install is blocked by 403 errors in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce76af1fbc8322aac05a89f68cb3a1